### PR TITLE
Add option to authenticate via Azure CLI

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -21,6 +21,7 @@ namespace FhirLoader
             Uri authority = null,
             string clientId = null,
             string clientSecret = null,
+            string accessToken = null,
             string bufferFileName = "resources.json",
             bool reCreateBufferIfExists = false,
             bool forcePost = false,
@@ -39,7 +40,7 @@ namespace FhirLoader
                 Console.WriteLine("Buffer created.");
             }
 
-            bool useAuth = authority != null && clientId != null && clientSecret != null;
+            bool useAuth = authority != null && clientId != null && clientSecret != null && accessToken == null;
 
             AuthenticationContext authContext = useAuth ? new AuthenticationContext(authority.AbsoluteUri, new TokenCache()) : null;
             ClientCredential clientCredential = useAuth ? new ClientCredential(clientId, clientSecret) : null;
@@ -87,6 +88,10 @@ namespace FhirLoader
                         {
                             var authResult = authContext.AcquireTokenAsync(fhirServerUrl.AbsoluteUri.TrimEnd('/'), clientCredential).Result;
                             message.Headers.Authorization = new AuthenticationHeaderValue("Bearer", authResult.AccessToken);
+                        }
+                        else if (accessToken != null)
+                        {
+                            message.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
                         }
 
                         return httpClient.SendAsync(message);


### PR DESCRIPTION
As discussed in https://github.com/microsoft/fhir-server-samples/pull/87#issuecomment-662111140, this pull request adds an option to the FhirLoader to authorize with an existing access token. This change enables scenarios like using Azure CLI to generate an access token for the current user and using that token to run FhirLoader, which makes FhirLoader easier to use as we no longer require first creating a service principal.