### PR TITLE
Add release pipeline

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,24 @@
+name: release
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  release:
+    runs-on: 'windows-latest'
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '3.1.x'
+
+      - run: dotnet publish --self-contained true --configuration Release --runtime win-x64 -p:PublishSingleFile=true --output .\pub
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: FhirLoader.exe
+          path: pub/FhirLoader.exe

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 obj/
 .vscode/
+.vs/
 *.json
 bin/

--- a/FhirLoader.sln
+++ b/FhirLoader.sln
@@ -1,4 +1,3 @@
-
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.30320.27
@@ -7,6 +6,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FhirLoader", "FhirLoader.cs
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{30EBF985-12C9-41ED-90CE-78FD785E7251}"
 	ProjectSection(SolutionItems) = preProject
+		.gitignore = .gitignore
 		.github\workflows\release.yaml = .github\workflows\release.yaml
 	EndProjectSection
 EndProject

--- a/FhirLoader.sln
+++ b/FhirLoader.sln
@@ -1,0 +1,30 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30320.27
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FhirLoader", "FhirLoader.csproj", "{FEA23758-131D-4464-BDE9-B351231636ED}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{30EBF985-12C9-41ED-90CE-78FD785E7251}"
+	ProjectSection(SolutionItems) = preProject
+		.github\workflows\release.yaml = .github\workflows\release.yaml
+	EndProjectSection
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{FEA23758-131D-4464-BDE9-B351231636ED}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FEA23758-131D-4464-BDE9-B351231636ED}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FEA23758-131D-4464-BDE9-B351231636ED}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FEA23758-131D-4464-BDE9-B351231636ED}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {9106AB7D-B192-4E47-8FA6-7C17C456DA9B}
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
This pull request adds a release pipeline using Github Actions. The pipeline publishes a self-contained binary of the FhirLoader to Github Artifacts so that the FhirLoader can more easily be consumed by users who may not have the dotnet CLI installed.

Links:
- [Sample pipeline run](https://github.com/c-w/FhirLoader/actions/runs/181470177)
- [Sample published binary](https://github.com/c-w/FhirLoader/suites/961053905/artifacts/12085790)
